### PR TITLE
feat (UX): clickable cues, mobile tweaks, and popup accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+TODOs.md

--- a/src/App.css
+++ b/src/App.css
@@ -180,7 +180,7 @@ img.logo-hover:hover {
   color: rgba(255, 255, 255, 0.95);
   font-size: 1.1rem;
   line-height: 1.4;
-  font-style: italic;
+  font-style: normal;
   font-weight: 500; /* slightly heavier than regular, but not bold */
   text-align: center;
   max-width: 400px;

--- a/src/App.css
+++ b/src/App.css
@@ -168,7 +168,7 @@ img.logo-hover:hover {
   background-color: #546930;
   color: #f9c49c;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(84, 105, 48, 0.4);
+  box-shadow: none;
 }
 
 .artist-description {

--- a/src/App.css
+++ b/src/App.css
@@ -60,6 +60,34 @@
   }
 }
 
+/* Occasional attention cue */
+.attention-cue {
+  will-change: transform;
+}
+
+.question .attention-cue {
+  animation: cue-pop 1.3s ease-out 1;
+}
+
+.logo-hover.attention-cue {
+  animation: cue-pop 1.3s ease-out 1;
+}
+
+@keyframes cue-pop {
+  0% {
+    transform: scale(1);
+  }
+  25% {
+    transform: scale(1.2);
+  }
+  55% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
 .l1 {
   margin-left: 150px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -16,6 +16,35 @@
 /* Only spans should be clickable, not the full paragraph width */
 .question .click-target {
   cursor: pointer;
+  display: inline-block;
+  will-change: transform;
+  transform-origin: center;
+}
+
+/* Subtle pulse cue for initial discoverability */
+.pulse-once {
+  animation: pulse-subtle 2.4s ease-out 1;
+}
+
+@keyframes pulse-subtle {
+  0% {
+    transform: scale(1);
+  }
+  15% {
+    transform: scale(1.12);
+  }
+  35% {
+    transform: scale(1);
+  }
+  55% {
+    transform: scale(1.08);
+  }
+  75% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 .l1 {

--- a/src/App.css
+++ b/src/App.css
@@ -21,6 +21,19 @@
   transform-origin: center;
 }
 
+/* Hover/focus affordances for clickable text */
+.question .click-target:hover,
+.question .click-target:focus-visible {
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+  transform: scale(1.06);
+}
+
+.question .click-target:focus-visible {
+  outline: 2px dotted #546930;
+  outline-offset: 2px;
+}
+
 /* Subtle pulse cue for initial discoverability */
 .pulse-once {
   animation: pulse-subtle 2.4s ease-out 1;
@@ -264,4 +277,10 @@ img.logo-hover:hover {
 
 .footer a:hover {
   text-decoration: underline;
+}
+
+/* Footer clickable affordances */
+.footer a:focus-visible {
+  outline: 2px dotted #546930;
+  outline-offset: 2px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -139,6 +139,7 @@ img.logo-hover:hover {
   font-size: 1.1rem;
   line-height: 1.4;
   font-style: italic;
+  font-weight: 500; /* slightly heavier than regular, but not bold */
   text-align: center;
   max-width: 400px;
   white-space: pre-line;
@@ -170,6 +171,7 @@ img.logo-hover:hover {
     font-size: 1rem;
     padding: 0.5rem 0.75rem;
     margin: 0.75rem 0;
+    text-align: left; /* align with the button on mobile */
   }
 
   /* Footer spacing only on mobile, slightly tighter but readable */

--- a/src/App.css
+++ b/src/App.css
@@ -153,6 +153,12 @@ img.logo-hover:hover {
     line-height: 0.6;
   }
 
+  /* Reduce vertical spacing between E, AGORA, and ? */
+  .question p {
+    margin-top: 0.7em;
+    margin-bottom: 0.7em;
+  }
+
   /* Nudge E right and ? left to frame AGORA */
   .question .l1 {
     margin-left: 28vw;

--- a/src/App.css
+++ b/src/App.css
@@ -66,22 +66,19 @@
 }
 
 .question .attention-cue {
-  animation: cue-pop 1.3s ease-out 1;
+  animation: cue-pop 2s ease-out 1;
 }
 
 .logo-hover.attention-cue {
-  animation: cue-pop 1.3s ease-out 1;
+  animation: cue-pop 2s ease-out 1;
 }
 
 @keyframes cue-pop {
   0% {
     transform: scale(1);
   }
-  25% {
-    transform: scale(1.2);
-  }
-  55% {
-    transform: scale(1.08);
+  45% {
+    transform: scale(1.15);
   }
   100% {
     transform: scale(1);

--- a/src/App.css
+++ b/src/App.css
@@ -181,6 +181,7 @@ img.logo-hover:hover {
   color: #546930;
   border: 2px solid #546930;
   padding: 10px 20px;
+  font-weight: 550;
   cursor: pointer;
   position: relative;
   display: inline-block;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ const App: React.FC = () => {
     useState<MovingObject | null>(null);
   const selectionCountsRef = useRef<Map<string, number>>(new Map());
   const [showPulse, setShowPulse] = useState<boolean>(true);
+  const [questionCueIndex, setQuestionCueIndex] = useState<number | null>(null);
 
   // Shared position tracking for collision detection
   const objectPositionsRef = useRef<Map<string, { top: number; left: number }>>(
@@ -96,6 +97,29 @@ const App: React.FC = () => {
     };
   }, []);
 
+  // Occasionally cue one of the question spans (E / AGORA / ?)
+  useEffect(() => {
+    let cancelled = false;
+    let timerId = 0 as unknown as number;
+
+    const scheduleNextCue = () => {
+      const delayMs = 4000 + Math.random() * 4000; // 4s - 8s
+      timerId = window.setTimeout(() => {
+        if (cancelled) return;
+        const index = Math.floor(Math.random() * 3); // 0,1,2
+        setQuestionCueIndex(index);
+        window.setTimeout(() => setQuestionCueIndex(null), 900);
+        if (!cancelled) scheduleNextCue();
+      }, delayMs);
+    };
+
+    scheduleNextCue();
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timerId);
+    };
+  }, []);
+
   // Handle position updates from moving elements
   const updateObjectPosition = useCallback(
     (elementId: string, position: { top: number; left: number }) => {
@@ -114,7 +138,7 @@ const App: React.FC = () => {
       <div className="question" ref={questionRef}>
         <p className="rotate1 l1 shadow-link">
           <span
-            className="click-target"
+            className={`click-target ${questionCueIndex === 0 ? 'attention-cue' : ''}`}
             role="button"
             tabIndex={0}
             aria-label="Abrir detalhes"
@@ -126,7 +150,7 @@ const App: React.FC = () => {
         </p>
         <p className="l2 shadow-link">
           <span
-            className={`click-target ${showPulse ? 'pulse-once' : ''}`}
+            className={`click-target ${showPulse ? 'pulse-once' : ''} ${questionCueIndex === 1 ? 'attention-cue' : ''}`}
             role="button"
             tabIndex={0}
             aria-label="Abrir detalhes"
@@ -138,7 +162,7 @@ const App: React.FC = () => {
         </p>
         <p className="rotate2 l3 shadow-link">
           <span
-            className="click-target"
+            className={`click-target ${questionCueIndex === 2 ? 'attention-cue' : ''}`}
             role="button"
             tabIndex={0}
             aria-label="Abrir detalhes"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const App: React.FC = () => {
   const [activeMovingObject, setActiveMovingObject] =
     useState<MovingObject | null>(null);
   const selectionCountsRef = useRef<Map<string, number>>(new Map());
+  const [showPulse, setShowPulse] = useState<boolean>(true);
 
   // Shared position tracking for collision detection
   const objectPositionsRef = useRef<Map<string, { top: number; left: number }>>(
@@ -71,6 +72,22 @@ const App: React.FC = () => {
     setShowPopUp(false);
   }
 
+  // Subtle pulse cue on first load (auto-stops after ~2.4s or on first interaction)
+  useEffect(() => {
+    const disablePulse = () => setShowPulse(false);
+    const timeoutId = window.setTimeout(disablePulse, 2400);
+    const onceOptions: AddEventListenerOptions & { once: boolean } = {
+      once: true,
+    };
+    window.addEventListener('pointerdown', disablePulse, onceOptions);
+    window.addEventListener('keydown', disablePulse, onceOptions);
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.removeEventListener('pointerdown', disablePulse);
+      window.removeEventListener('keydown', disablePulse);
+    };
+  }, []);
+
   // Handle position updates from moving elements
   const updateObjectPosition = useCallback(
     (elementId: string, position: { top: number; left: number }) => {
@@ -97,7 +114,7 @@ const App: React.FC = () => {
         </p>
         <p className="l2 shadow-link">
           <span
-            className="click-target"
+            className={`click-target ${showPulse ? 'pulse-once' : ''}`}
             onClick={() => openPopUp(eAgoraObject)}
           >
             AGORA

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ const App: React.FC = () => {
   const [activeMovingObject, setActiveMovingObject] =
     useState<MovingObject | null>(null);
   const selectionCountsRef = useRef<Map<string, number>>(new Map());
-  const [showPulse, setShowPulse] = useState<boolean>(true);
+  // Question cue index controls which of E/AGORA/? pulses
   const [questionCueIndex, setQuestionCueIndex] = useState<number | null>(null);
 
   // Shared position tracking for collision detection
@@ -81,34 +81,19 @@ const App: React.FC = () => {
     }
   }, []);
 
-  // Subtle pulse cue on first load (auto-stops after ~2.4s or on first interaction)
-  useEffect(() => {
-    const disablePulse = () => setShowPulse(false);
-    const timeoutId = window.setTimeout(disablePulse, 2400);
-    const onceOptions: AddEventListenerOptions & { once: boolean } = {
-      once: true,
-    };
-    window.addEventListener('pointerdown', disablePulse, onceOptions);
-    window.addEventListener('keydown', disablePulse, onceOptions);
-    return () => {
-      window.clearTimeout(timeoutId);
-      window.removeEventListener('pointerdown', disablePulse);
-      window.removeEventListener('keydown', disablePulse);
-    };
-  }, []);
-
   // Occasionally cue one of the question spans (E / AGORA / ?)
   useEffect(() => {
     let cancelled = false;
     let timerId = 0 as unknown as number;
+    const PULSE_DURATION_MS = 2400; // match .pulse-once animation length
 
     const scheduleNextCue = () => {
-      const delayMs = 4000 + Math.random() * 4000; // 4s - 8s
+      const delayMs = 2500 + Math.random() * 2500; // ~2.5s - 5s
       timerId = window.setTimeout(() => {
         if (cancelled) return;
         const index = Math.floor(Math.random() * 3); // 0,1,2
         setQuestionCueIndex(index);
-        window.setTimeout(() => setQuestionCueIndex(null), 900);
+        window.setTimeout(() => setQuestionCueIndex(null), PULSE_DURATION_MS);
         if (!cancelled) scheduleNextCue();
       }, delayMs);
     };
@@ -138,7 +123,7 @@ const App: React.FC = () => {
       <div className="question" ref={questionRef}>
         <p className="rotate1 l1 shadow-link">
           <span
-            className={`click-target ${questionCueIndex === 0 ? 'attention-cue' : ''}`}
+            className={`click-target ${questionCueIndex === 0 ? 'pulse-once' : ''}`}
             role="button"
             tabIndex={0}
             aria-label="Abrir detalhes"
@@ -150,7 +135,7 @@ const App: React.FC = () => {
         </p>
         <p className="l2 shadow-link">
           <span
-            className={`click-target ${showPulse ? 'pulse-once' : ''} ${questionCueIndex === 1 ? 'attention-cue' : ''}`}
+            className={`click-target ${questionCueIndex === 1 ? 'pulse-once' : ''}`}
             role="button"
             tabIndex={0}
             aria-label="Abrir detalhes"
@@ -162,7 +147,7 @@ const App: React.FC = () => {
         </p>
         <p className="rotate2 l3 shadow-link">
           <span
-            className={`click-target ${questionCueIndex === 2 ? 'attention-cue' : ''}`}
+            className={`click-target ${questionCueIndex === 2 ? 'pulse-once' : ''}`}
             role="button"
             tabIndex={0}
             aria-label="Abrir detalhes"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,14 @@ const App: React.FC = () => {
     setShowPopUp(false);
   }
 
+  // Accessibility: keyboard activate on Enter/Space for clickable spans
+  const handleClickTargetKeyDown = useCallback((event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openPopUp(eAgoraObject);
+    }
+  }, []);
+
   // Subtle pulse cue on first load (auto-stops after ~2.4s or on first interaction)
   useEffect(() => {
     const disablePulse = () => setShowPulse(false);
@@ -107,6 +115,10 @@ const App: React.FC = () => {
         <p className="rotate1 l1 shadow-link">
           <span
             className="click-target"
+            role="button"
+            tabIndex={0}
+            aria-label="Abrir detalhes"
+            onKeyDown={handleClickTargetKeyDown}
             onClick={() => openPopUp(eAgoraObject)}
           >
             E
@@ -115,6 +127,10 @@ const App: React.FC = () => {
         <p className="l2 shadow-link">
           <span
             className={`click-target ${showPulse ? 'pulse-once' : ''}`}
+            role="button"
+            tabIndex={0}
+            aria-label="Abrir detalhes"
+            onKeyDown={handleClickTargetKeyDown}
             onClick={() => openPopUp(eAgoraObject)}
           >
             AGORA
@@ -123,6 +139,10 @@ const App: React.FC = () => {
         <p className="rotate2 l3 shadow-link">
           <span
             className="click-target"
+            role="button"
+            tabIndex={0}
+            aria-label="Abrir detalhes"
+            onKeyDown={handleClickTargetKeyDown}
             onClick={() => openPopUp(eAgoraObject)}
           >
             ?

--- a/src/components/MovingElement.tsx
+++ b/src/components/MovingElement.tsx
@@ -34,6 +34,7 @@ const MovingElement: React.FC<MovingElementProps> = ({
   const [position, setPosition] = useState<Position>({ top: 0, left: 0 });
   const [currentMovingObject, setcurrentMovingObject] =
     useState<MovingObject>();
+  const [shouldCue, setShouldCue] = useState<boolean>(false);
   const hasSetInitialImage = useRef(false);
   const objectPositionsRef = useRef(existingPositions);
 
@@ -47,6 +48,28 @@ const MovingElement: React.FC<MovingElementProps> = ({
   useEffect(() => {
     objectPositionsRef.current = existingPositions;
   }, [existingPositions]);
+
+  // Occasionally cue the moving element for clickability
+  useEffect(() => {
+    let cancelled = false;
+    let timerId = 0 as unknown as number;
+
+    const scheduleNextCue = () => {
+      const delayMs = 7000 + Math.random() * 9000; // 7s - 16s
+      timerId = window.setTimeout(() => {
+        if (cancelled) return;
+        setShouldCue(true);
+        window.setTimeout(() => setShouldCue(false), 800);
+        if (!cancelled) scheduleNextCue();
+      }, delayMs);
+    };
+
+    scheduleNextCue();
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timerId);
+    };
+  }, []);
 
   const getPosition = useCallback(
     (useCurrentPositions: boolean = false): Position => {
@@ -175,7 +198,7 @@ const MovingElement: React.FC<MovingElementProps> = ({
             height: 'auto',
             transition: `transform ${ANIMATION_CONSTANTS.TRANSFORM_TRANSITION_DURATION} ease`,
           }}
-          className="logo-hover"
+          className={`logo-hover ${shouldCue ? 'attention-cue' : ''}`}
           onClick={() => onClick(currentMovingObject)}
         />
       )}

--- a/src/components/PopupModal.tsx
+++ b/src/components/PopupModal.tsx
@@ -49,7 +49,7 @@ const PopupModal: React.FC<PopupModalProps> = ({
           <a
             href={movingObject.ticketsLink!}
             target="_blank"
-            className="button shadow-link"
+            className="button"
           >
             E agora? Bilhetes aqui&nbsp;{' '}
             <i className="fa fa-ticket" aria-hidden="true"></i>
@@ -58,7 +58,7 @@ const PopupModal: React.FC<PopupModalProps> = ({
           <a
             href={movingObject.location || ''}
             target="_blank"
-            className="button shadow-link"
+            className="button"
           >
             Entrada Livre&nbsp;{' '}
             <i className="fa fa-map-marker" aria-hidden="true"></i>

--- a/src/components/PopupModal.tsx
+++ b/src/components/PopupModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { MovingObject } from '../types/MovingObject';
 
 interface PopupModalProps {
@@ -12,6 +12,20 @@ const PopupModal: React.FC<PopupModalProps> = ({
   movingObject,
   onClose,
 }) => {
+  // Close on Escape key for accessibility
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKeyUp(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    }
+
+    window.addEventListener('keyup', handleKeyUp);
+    return () => window.removeEventListener('keyup', handleKeyUp);
+  }, [isOpen, onClose]);
+
   if (!isOpen || !movingObject) return null;
 
   const hasTickets = !!movingObject.ticketsLink;

--- a/src/data/descriptions.ts
+++ b/src/data/descriptions.ts
@@ -1,6 +1,6 @@
 export const DESCRIPTIONS = {
   cartaz:
-    'A Associação 140 convida o público para mais uma edição do GumaJazz, um evento que celebra o jazz, a improvisação, o artesanato e a criação comunitária no coração do verão.\nO festival acontece no dia 17 de agosto de 2025, a partir das 15h.',
+    'A Associação 140 convida o público para mais uma edição do GumaJazz, um evento que celebra o jazz, a improvisação, o artesanato e a criação comunitária no coração do verão. O festival acontece no dia 17 de agosto de 2025, a partir das 15h.',
   workshop15h:
     'O Clara Lacerda Trio dinamiza um workshop aberto a todas as pessoas a partir dos 6 anos, músicos e não músicos. Uma proposta educativa e sensorial que celebra a improvisação como linguagem inclusiva.',
   gentrifugacao17h:


### PR DESCRIPTION
### What’s new

- Question text pulses randomly to hint interactivity
- Logos cue / animate after they stop moving
- Popup: description left-aligned on mobile, no italics, heavier text; buttons thicker (550) and no hover shadow
- Accessibility: E/AGORA/? keyboard-activatable; popup closes on Esc
- Mobile: tighter spacing on question lines; footer links keep clean focus outline