### PR TITLE
feat(analytics): prod-only GTM and code-driven events (modal/moving/footer)

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,33 +10,28 @@
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Associação 140</title>
-    <!-- Google Tag Manager -->
+    <!-- Google Tag Manager (production only) -->
     <script>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : '';
-        j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-5QWP4NFT');
+      (function () {
+        var h = window.location.hostname;
+        if (h === '140.pt' || h === 'www.140.pt') {
+          (function (w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+            var f = d.getElementsByTagName(s)[0],
+              j = d.createElement(s),
+              dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+          })(window, document, 'script', 'dataLayer', 'GTM-5QWP4NFT');
+        }
+      })();
     </script>
     <!-- End Google Tag Manager -->
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript
-      ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-5QWP4NFT"
-        height="0"
-        width="0"
-        style="display: none; visibility: hidden"
-      ></iframe
-    ></noscript>
-    <!-- End Google Tag Manager (noscript) -->
   </body>
 </html>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from 'react';
+import { trackCtaClick } from '../../utils/analytics';
 import { FORMS } from '../../data/constants';
 import './Footer.css';
 
@@ -10,7 +11,19 @@ const Footer = forwardRef<HTMLElement>((_props, ref) => {
       </p>
       <p>Movimento Artístico e Sociocultural</p>
       <p>
-        <a href={FORMS.fichaSocio} target="_blank" rel="noopener noreferrer">
+        <a
+          href={FORMS.fichaSocio}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() =>
+            trackCtaClick({
+              context: 'footer',
+              ctaType: 'external_link',
+              linkUrl: FORMS.fichaSocio,
+              linkText: 'Torna-te sócio!',
+            })
+          }
+        >
           <strong>Torna-te sócio!</strong>
         </a>
       </p>
@@ -21,6 +34,14 @@ const Footer = forwardRef<HTMLElement>((_props, ref) => {
           href="https://www.instagram.com/cento.quarenta/"
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() =>
+            trackCtaClick({
+              context: 'footer',
+              ctaType: 'external_link',
+              linkUrl: 'https://www.instagram.com/cento.quarenta/',
+              linkText: 'cento.quarenta',
+            })
+          }
         >
           cento.quarenta
         </a>
@@ -28,7 +49,19 @@ const Footer = forwardRef<HTMLElement>((_props, ref) => {
       <p>
         <i className="fa fa-envelope-o" aria-hidden="true"></i>
         &nbsp;
-        <a href="mailto:geral@140.pt">geral@140.pt</a>
+        <a
+          href="mailto:geral@140.pt"
+          onClick={() =>
+            trackCtaClick({
+              context: 'footer',
+              ctaType: 'external_link',
+              linkUrl: 'mailto:geral@140.pt',
+              linkText: 'geral@140.pt',
+            })
+          }
+        >
+          geral@140.pt
+        </a>
       </p>
       <p>
         <i className="fa fa-copyright" aria-hidden="true"></i>

--- a/src/components/moving/MovingElement.tsx
+++ b/src/components/moving/MovingElement.tsx
@@ -7,6 +7,7 @@ import { selectWeightedRandom } from '../../utils/weightedSelection';
 import { generatePosition } from '../../utils/positionHelpers';
 import { useMovingObjects } from '../../contexts/MovingObjectsContext';
 import { ANIMATION_CONSTANTS } from '../../data/constants';
+import { trackCtaClick, trackModalOpen } from '../../utils/analytics';
 
 interface MovingElementProps {
   elementId: string;
@@ -211,6 +212,13 @@ const MovingElement: React.FC<MovingElementProps> = ({
           href={currentMovingObject.formLink}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => {
+            trackCtaClick({
+              context: 'moving_element',
+              ctaType: 'form_link',
+              linkUrl: currentMovingObject.formLink as string,
+            });
+          }}
         >
           <img
             src={currentMovingObject.image}
@@ -228,11 +236,25 @@ const MovingElement: React.FC<MovingElementProps> = ({
           tabIndex={0}
           aria-label="Abrir detalhes"
           className={`moving-element-hover ${shouldCue ? 'attention-cue' : ''}`}
-          onClick={() => onClick(currentMovingObject)}
+          onClick={() => {
+            onClick(currentMovingObject);
+            trackModalOpen({
+              context: 'moving_element',
+              objectImage: currentMovingObject.image,
+              hasTickets: !!currentMovingObject.ticketsLink,
+              hasLocation: !!currentMovingObject.location,
+            });
+          }}
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
               onClick(currentMovingObject);
+              trackModalOpen({
+                context: 'moving_element',
+                objectImage: currentMovingObject.image,
+                hasTickets: !!currentMovingObject.ticketsLink,
+                hasLocation: !!currentMovingObject.location,
+              });
             }
           }}
         />

--- a/src/components/ui/PopupModal.tsx
+++ b/src/components/ui/PopupModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import './PopupModal.css';
 import { MovingObject } from '../../types/MovingObject';
+import { trackCtaClick } from '../../utils/analytics';
 
 interface PopupModalProps {
   isOpen: boolean;
@@ -56,7 +57,11 @@ const PopupModal: React.FC<PopupModalProps> = ({
       role="dialog"
       aria-modal="true"
       aria-label="Detalhes do evento"
-      onClick={handleRequestClose}
+      onClick={(e) => {
+        if (e.currentTarget === e.target) {
+          handleRequestClose();
+        }
+      }}
     >
       <div className="popup-content" tabIndex={-1}>
         <button
@@ -73,7 +78,14 @@ const PopupModal: React.FC<PopupModalProps> = ({
             href={movingObject.ticketsLink!}
             target="_blank"
             rel="noopener noreferrer nofollow"
-            onClick={(e) => e.stopPropagation()}
+            onClick={() =>
+              trackCtaClick({
+                context: 'modal',
+                ctaType: 'tickets',
+                linkUrl: movingObject.ticketsLink as string,
+                linkText: 'Poster',
+              })
+            }
           >
             <img src={movingObject.image} alt="Pop-up Poster" />
           </a>
@@ -107,7 +119,14 @@ const PopupModal: React.FC<PopupModalProps> = ({
             target="_blank"
             rel="noopener noreferrer nofollow"
             className="button"
-            onClick={(e) => e.stopPropagation()}
+            onClick={() =>
+              trackCtaClick({
+                context: 'modal',
+                ctaType: 'tickets',
+                linkUrl: movingObject.ticketsLink as string,
+                linkText: 'E agora? Bilhetes aqui',
+              })
+            }
           >
             E agora? Bilhetes aqui&nbsp;{' '}
             <i className="fa fa-ticket" aria-hidden="true"></i>
@@ -118,7 +137,14 @@ const PopupModal: React.FC<PopupModalProps> = ({
             target="_blank"
             rel="noopener noreferrer nofollow"
             className="button"
-            onClick={(e) => e.stopPropagation()}
+            onClick={() =>
+              trackCtaClick({
+                context: 'modal',
+                ctaType: 'location',
+                linkUrl: movingObject.location || '',
+                linkText: 'Entrada Livre',
+              })
+            }
           >
             Entrada Livre&nbsp;{' '}
             <i className="fa fa-map-marker" aria-hidden="true"></i>

--- a/src/contexts/UIStateContext.tsx
+++ b/src/contexts/UIStateContext.tsx
@@ -6,6 +6,7 @@ import {
   ReactNode,
 } from 'react';
 import { MovingObject } from '../types/MovingObject';
+import { trackModalOpen } from '../utils/analytics';
 
 /**
  * UI State interface
@@ -84,6 +85,12 @@ export function UIStateProvider({
 
   const openHeaderPopup = useCallback(() => {
     openPopup(headerObject);
+    trackModalOpen({
+      context: 'header',
+      objectImage: headerObject.image,
+      hasTickets: !!headerObject.ticketsLink,
+      hasLocation: !!headerObject.location,
+    });
   }, [openPopup, headerObject]);
 
   // Context value

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,81 @@
+/*
+ * Lightweight analytics helpers that only emit events on production hostnames.
+ * Designed to minimize GTM logic by pushing well-structured dataLayer events.
+ */
+
+interface GtagFunction {
+  (command: 'event', eventName: string, params?: Record<string, unknown>): void;
+  (
+    command: 'config',
+    measurementId: string,
+    params?: Record<string, unknown>,
+  ): void;
+}
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: GtagFunction;
+  }
+}
+
+function isProdHostname(): boolean {
+  if (typeof window === 'undefined') return false;
+  const hostname = window.location.hostname;
+  return hostname === '140.pt' || hostname === 'www.140.pt';
+}
+
+function ensureDataLayer(): unknown[] {
+  if (!Array.isArray(window.dataLayer)) {
+    window.dataLayer = [];
+  }
+  return window.dataLayer;
+}
+
+export function track(
+  eventName: string,
+  params?: Record<string, unknown>,
+): void {
+  if (!isProdHostname()) return;
+  const payload: Record<string, unknown> = {
+    event: 'app_event',
+    event_name: eventName,
+  };
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      payload[key] = value;
+    }
+  }
+  ensureDataLayer().push(payload);
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', eventName, params);
+  }
+}
+
+export function trackModalOpen(details: {
+  context: 'moving_element' | 'header';
+  objectImage: string;
+  hasTickets: boolean;
+  hasLocation: boolean;
+}): void {
+  track('modal_open', {
+    context: details.context,
+    object_image: details.objectImage,
+    has_tickets: details.hasTickets,
+    has_location: details.hasLocation,
+  });
+}
+
+export function trackCtaClick(details: {
+  context: 'moving_element' | 'modal' | 'modal_image' | 'footer' | 'header';
+  ctaType: 'tickets' | 'location' | 'form_link' | 'external_link';
+  linkUrl: string;
+  linkText?: string;
+}): void {
+  track('cta_click', {
+    context: details.context,
+    cta_type: details.ctaType,
+    link_url: details.linkUrl,
+    link_text: details.linkText,
+  });
+}


### PR DESCRIPTION
### Why
- **Noise from non‑prod**: GA received test-domain traffic (/140).
- **Goal**: Prod‑only tracking with simple, consistent event schema.

### What changed
- **GTM gating**: `index.html` loads GTM only on `140.pt`/`www.140.pt`; removed `<noscript>`.
- **Analytics helper**: `src/utils/analytics.ts` – `track`, `trackModalOpen`, `trackCtaClick` (prod‑gated; emits `gtag` + `dataLayer`).
- **Instrumentation**:
  - `src/components/moving/MovingElement.tsx`: `modal_open` (image), `cta_click` (formLink).
  - `src/components/ui/PopupModal.tsx`: `cta_click` (tickets/location/poster). Backdrop closes only on backdrop to allow link bubbling.
  - `src/components/layout/Footer.tsx`: `cta_click` (join/instagram/email).
  - `src/contexts/UIStateContext.tsx`: `modal_open` when header opens modal.

### Events
- **modal_open**: `context` (moving_element|header), `object_image`, `has_tickets`, `has_location`
- **cta_click**: `context` (moving_element|modal|footer), `cta_type` (form_link|tickets|location|external_link), `link_url`, `link_text`

### Testing
- **Tag Assistant** (140.pt): container loads; `app_event` entries visible with params.
- **GA Realtime**: see `modal_open` / `cta_click`.
- **GitHub Pages**: GTM blocked; no events.

### Option A vs B
- **Option A (implemented)**: code‑driven events
  - Pros: minimal GTM, consistent schema, fewer moving parts.
  - Cons: schema changes require code deploy.
- **Option B**: single GTM Custom Event tag for `app_event`
  - Pros: adjust mapping/enrichment in GTM without deploy; clearer tag timelines.
  - Cons: more GTM config; must avoid duplicates if `gtag` also fires.

### Impact
- **Prod‑only analytics**, no `/140` test paths.
- **Structured, actionable events** with minimal GTM configuration.
- **No tracking without JS** (noscript removed by design).